### PR TITLE
Improve the install script, fix the systemd service and add desktop notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,21 @@ Shadowplay's replay feature on Linux
 	- `sudo pacman -S ffmpeg`
 - Have Xbindkeys installed
 	- `sudo pacman -S xbindkeys`
+- Have libnotify installed
+   - `sudo pacman -S libnotify`
+
+## Installation
+
+Download this repository and run the `install` file.
+This will install the required dependencies on Arch and install the systemd user service.
 
 ## Configuration
 
+Edit the variables in the `shadowplay` file to configure.
+
 - Change `FPS` to your desired recording framerate. Default is 60.
 
-- Change `RESOLUTION` to your resolution. (X11 resolution). Default is 1920x1080.
+- Change `RESOLUTION` to your resolution. (X11 resolution). Default is your main monitor resolution.
 
 - Change `REPLAY_BUFFER` to your desired save time. Default is 00:05:00 for 5min. 
 

--- a/install
+++ b/install
@@ -1,5 +1,37 @@
 #!/bin/sh
-sudo mv shadowplay /usr/local/bin/
-# mv shadowplay.service "$HOME"/config/systemd/user/
-# mv shadowplay.timer "$HOME"/config/systemd/user/
-# systemctl --user enable --now shadowplay
+
+DIR=$(dirname "$0")
+
+# Install dependencies on Arch
+if [ -e "/etc/arch-release" ]; then
+    echo "Installing dependencies"
+    sudo pacman --noconfirm -S xbindkeys ffmpeg libnotify
+fi
+
+# move shadowplay to /usr/bin
+sudo install "$DIR/shadowplay" /usr/local/bin 
+
+# Save the xbindkeys config
+echo """
+# make F9 save Shadowplay replay
+"killall --user $USER --ignore-case --signal SIGTERM ffmpeg"
+   F9
+
+# make F10 kill Shadowplay
+"killall -s1 ffmpeg"
+   F10
+""" >> "$HOME/.xbindkeysrc"
+
+# Install systemd user service
+mkdir -p "$HOME/.config/systemd/user/"
+cp "$DIR/shadowplay.service" "$HOME/.config/systemd/user/"
+cp "$DIR/shadowplay.timer" "$HOME/.config/systemd/user/"
+# Start shadowplay service
+systemctl --user enable --now shadowplay
+systemctl --user restart --now shadowplay
+
+echo """
+
+
+Installation is complete!
+Press F9 to save a replay"""

--- a/shadowplay
+++ b/shadowplay
@@ -3,7 +3,7 @@
 set -eu
 
 # Resolution of your X session
-RESOLUTION="$(xdpyinfo | grep dimensions | awk '{print $2}')"
+RESOLUTION="$(xdpyinfo | grep dimensions | awk 'NR==1{print $2}')"
 
 # If you want to use CPU-encoding
 # instead, set to true.

--- a/shadowplay
+++ b/shadowplay
@@ -24,7 +24,7 @@ ENCODER_STANDARD=h264
 REPLAY_BUFFER="00:05:00"
 
 # Location to save recordings
-VIDEO_FOLDER="$HOME/Videos/"
+VIDEO_FOLDER="$HOME/Videos"
 
 if [ -e "$VIDEO_FOLDER" ]; then
     echo "Video directory already exists."
@@ -50,7 +50,7 @@ fi
 BASEDIR=$(dirname "$0")
 
 DATE=$(date +%Y-%d-%m-%H:%M:%S)
-FILE="$VIDEO_FOLDER"/replay-"$DATE".mp4
+FILE="$VIDEO_FOLDER/replay-$DATE.mp4"
 
 case $ENCODER_API in
     "vaapi")

--- a/shadowplay
+++ b/shadowplay
@@ -127,6 +127,10 @@ ffmpeg \
 
 rm /tmp/shadowplay.mp4 &&
 
+notify-send -i video \
+	"Shadowplay" \
+	"Replay saved to $FILE"
+
 cd "$BASEDIR" &&
     
 ./shadowplay

--- a/shadowplay.service
+++ b/shadowplay.service
@@ -2,5 +2,6 @@
 Description=Achieve ShadowPlay-like functionality on Linux
 
 [Service]
+ExecStartPre=/usr/bin/xbindkeys -f "%h/.xbindkeysrc"
 ExecStart=/usr/local/bin/shadowplay
 invironment=DISPLAY=:0

--- a/shadowplay.service
+++ b/shadowplay.service
@@ -4,6 +4,7 @@ Description=Achieve ShadowPlay-like functionality on Linux
 [Service]
 ExecStartPre=/usr/bin/xbindkeys -f "%h/.xbindkeysrc"
 ExecStart=/usr/local/bin/shadowplay
-invironment=DISPLAY=:0
+#Environment=DISPLAY=:0
+
 [Install]
 WantedBy=multi-user.target

--- a/shadowplay.service
+++ b/shadowplay.service
@@ -5,3 +5,5 @@ Description=Achieve ShadowPlay-like functionality on Linux
 ExecStartPre=/usr/bin/xbindkeys -f "%h/.xbindkeysrc"
 ExecStart=/usr/local/bin/shadowplay
 invironment=DISPLAY=:0
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
The install script will now download the required dependencies when using Arch Linux, install the systemd user service and enable it and create the xbindkeys config.

The systemd service wouldn't start because it needed
```
[Install]
WantedBy=multi-user.target
```
Also fixed the typo. On my machine `DISPLAY` is set to `:1` and setting it to `:0` breaks the script.

I've also added desktop notification support using libnotify and added more info in the README file